### PR TITLE
Add timeout to authentication

### DIFF
--- a/axiomapy/session.py
+++ b/axiomapy/session.py
@@ -844,7 +844,7 @@ class SimpleAuthSession(AxiomaSession):
         certificates = self.certificates
         _logger.info("Preparing to authenticate:")
 
-        with httpx.Client(proxies=proxy, verify=certificates) as client:
+        with httpx.Client(proxies=proxy, verify=certificates, timeout=self.timeout) as client:
             response = client.post(self.auth_url, data=credentials, headers=headers)
 
         _logger.info(f"Sending authentication request to {self.auth_url}")


### PR DESCRIPTION
Currently axioma-py allows users to set timeout for requests post authentication. However, the same is not applicable for login and users are facing Timeout issues with the same. Here is jira for reference: https://qontigo-cloud.atlassian.net/browse/AXIOMAPY-64